### PR TITLE
Fallback to lsbmajdistrelease, if puppet version is < 3.0

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,13 @@ class selinux::params {
               $sx_fs_mount = '/selinux'
               $package_name = 'policycoreutils'
             }
+            '': {
+              # Fallback to lsbmajdistrelease, if puppet version is < 3.0
+              if($::lsbmajdistrelease == 5) {
+                $sx_fs_mount = '/selinux'
+                $package_name = 'policycoreutils'
+              }
+            }
             default: {
               fail("${::operatingsystem}-${::operatingsystemmajrelease} is not supported")
             }


### PR DESCRIPTION
Hello,

we use the new Sattelite 6.1 with Red Hat supported puppet packages.

For RHEL5, the package version is 2.7.23.

The facter operatingsystemmajrelease is named on 2.7.X, a simply fallback to lsbmajdistrelease is used, if the operatingsystemmajrelease is empty.